### PR TITLE
Display actual usage, rather than nominal size; depessimise nftw() for deep trees

### DIFF
--- a/filepie.cpp
+++ b/filepie.cpp
@@ -87,7 +87,7 @@ namespace {
   static std::size_t running_size = 0;
   int visitor_sum_size(const char*, const struct stat *sb, int, struct FTW*)
   {
-    running_size += sb->st_size;
+    running_size += std::size_t(sb->st_blocks) * 512;
     return 0;
   }
 

--- a/filepie.cpp
+++ b/filepie.cpp
@@ -125,7 +125,7 @@ std::vector<std::tuple<std::string, std::size_t, bool, float>> get_files(std::st
     bool is_dir = S_ISDIR(st.st_mode);
 
     running_size = 0;
-    if (nftw(temp, &visitor_sum_size, 1, FTW_PHYS)) {
+    if (nftw(temp, &visitor_sum_size, 128, FTW_PHYS)) {
       printf("Error while accessing %s\n", temp);
       perror("ftw");
     }


### PR DESCRIPTION
Fixes sparse files on traditional filesystems (and compression on like ZFS), and provides an infinite improvement in speed for my very deep tree